### PR TITLE
Added basic debian support and simple tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,13 @@ Default: 'present'
 Limitations
 -----------
 
-At present, only support for `$::osfamily == 'RedHat'` has been implimented.
+At present, only supports Debian and Redhat based distributions.
 
 ### Tested Platforms
 
 * el5.x
 * el6.x
+* Ubuntu/Debian
 
 
 Support

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,16 @@ class autofsck ($ensure = 'present') {
         content => "AUTOFSCK_DEF_CHECK=\"yes\"\nAUTOFSCK_OPT=\"-y\"\n",
       }
     }
+    Debian: {
+      $set_fsckfix = $ensure ? {
+        'present' => 'yes',
+        'absent'  => 'no',
+      }
+      augeas { 'fsckfix':
+        context => '/files/etc/default/rcS',
+        changes => "set FSCKFIX ${set_fsckfix}",
+      }
+    }
     default: {
       fail("Module ${module_name} is not supported on ${::operatingsystem}")
     }

--- a/spec/classes/autofsck_spec.rb
+++ b/spec/classes/autofsck_spec.rb
@@ -47,9 +47,28 @@ describe 'autofsck', :type => :class do
     end
   end
 
+  context 'On Debian' do
+    describe 'With ensure => present' do
+      let(:facts) { {:osfamily=> 'Debian'} }
+      let(:params) { {:ensure => 'present'} }
+      it { should_not contain_file('/etc/sysconfig/autofsck') }
+      it { should contain_augeas('fsckfix').\
+        with_changes('set FSCKFIX yes')
+      }
+    end
+    describe 'With ensure => absent' do
+      let(:facts) { {:osfamily=> 'Debian'} }
+      let(:params) { {:ensure => 'absent'} }
+      it { should_not contain_file('/etc/sysconfig/autofsck') }
+      it { should contain_augeas('fsckfix').\
+        with_changes('set FSCKFIX no')
+      }
+    end
+  end
+
   # fail on unsupported osfamily
   describe 'unsupported osfamily' do
-    let(:facts) { {:osfamily=> 'Debian'} }
+    let(:facts) { {:osfamily=> 'Freebsd'} }
  
     it do
       expect {


### PR DESCRIPTION
Works on my stuff. Decently tested. Fixes issue #1. 

I feel like now that you have both OSes, "enable => true/false" seems more appropriate than ensure => present/absent. (because it is no longer just a file), but that is just personal preference. 
