### PR TITLE
Matches in case statements must be quoted in Puppet 4

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,7 @@ class autofsck ($ensure = 'present') {
   validate_re($ensure, '^present$|^absent$')
 
   case $::osfamily {
-    RedHat: {
+    'RedHat': {
       file { '/etc/sysconfig/autofsck':
         ensure  => $ensure,
         owner   => 'root',
@@ -39,7 +39,7 @@ class autofsck ($ensure = 'present') {
         content => "AUTOFSCK_DEF_CHECK=\"yes\"\nAUTOFSCK_OPT=\"-y\"\n",
       }
     }
-    Debian: {
+    'Debian': {
       $set_fsckfix = $ensure ? {
         'present' => 'yes',
         'absent'  => 'no',


### PR DESCRIPTION
The syntax in Puppet 4 is more strict that it was for Puppet 3.

This fix adds quotes to the matches in the case statement to make the module work with Puppet 4.
